### PR TITLE
Add new call to load config from file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,20 @@
 use std::ffi::CString;
-use std::os::raw::{c_char, c_int};
+use std::os::raw::{c_char, c_int, c_uchar, c_uint};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::RawFd;
 use std::path::Path;
 use std::result::Result;
 
 extern "C" {
-    fn hev_socks5_tunnel_main(config_path: *const c_char, tun_fd: c_int) -> c_int;
+    fn hev_socks5_tunnel_main_from_file(config_path: *const c_char, tun_fd: c_int) -> c_int;
+}
+
+extern "C" {
+    fn hev_socks5_tunnel_main_from_str(
+        config_str: *const c_uchar,
+        config_len: c_uint,
+        tun_fd: c_int,
+    ) -> c_int;
 }
 
 extern "C" {
@@ -24,13 +32,32 @@ extern "C" {
 /// # Returns
 ///
 /// Returns zero on successful, otherwise returns -1.
-pub fn main(config_path: &Path, tun_fd: RawFd) -> Result<(), i32> {
+pub fn main_from_file(config_path: &Path, tun_fd: RawFd) -> Result<(), i32> {
     let path = CString::new(config_path.as_os_str().as_bytes()).unwrap();
-    let res;
+    let res = unsafe { hev_socks5_tunnel_main_from_file(path.as_ptr(), tun_fd) };
 
-    unsafe {
-        res = hev_socks5_tunnel_main(path.as_ptr() as *const i8, tun_fd);
+    match res {
+        0 => Ok(()),
+        r => Err(r),
     }
+}
+
+/// Start and run the socks5 tunnel, this function will blocks until the
+/// quit() is called or an error occurs.
+///
+/// # Arguments
+///
+/// * `config_str` - config string
+/// * `tun_fd` - tunnel file descriptor
+///
+/// # Returns
+///
+/// Returns zero on successful, otherwise returns -1.
+pub fn main_from_str(config_str: &str, tun_fd: RawFd) -> Result<(), i32> {
+    let config_bytes = config_str.as_bytes();
+    let res = unsafe {
+        hev_socks5_tunnel_main_from_str(config_bytes.as_ptr(), config_bytes.len() as c_uint, tun_fd)
+    };
 
     match res {
         0 => Ok(()),


### PR DESCRIPTION
Even though this should be enough to bring support for loading config from string, I am still unable to compile this crate on my Intel Mac when it's specified as a dependency in Cargo.toml.

```
ld: Undefined symbols:
            _hev_task_execute, referenced from:
                _hev_task_system_run_new_task in libtun2socks-40d79f8fb809d21e.rlib[46](hev-task-system-schedule.o)
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I am gonna leave the PR though in case you decide to merge it as it builds on its own.